### PR TITLE
Feature/resampling

### DIFF
--- a/amcl/include/amcl/pf/pf.h
+++ b/amcl/include/amcl/pf/pf.h
@@ -46,12 +46,12 @@ typedef pf_vector_t (*pf_init_model_fn_t) (void *init_data);
 
 // Function prototype for the action model; generates a sample pose from
 // an appropriate distribution
-typedef void (*pf_action_model_fn_t) (void *action_data, 
+typedef void (*pf_action_model_fn_t) (void *action_data,
                                       struct _pf_sample_set_t* set);
 
 // Function prototype for the sensor model; determines the probability
 // for the given set of sample poses.
-typedef double (*pf_sensor_model_fn_t) (void *sensor_data, 
+typedef double (*pf_sensor_model_fn_t) (void *sensor_data,
                                         struct _pf_sample_set_t* set);
 
 
@@ -63,7 +63,7 @@ typedef struct
 
   // Weight for this pose
   double weight;
-  
+
 } pf_sample_t;
 
 
@@ -82,7 +82,7 @@ typedef struct
 
   // Workspace
   double m[4], c[2][2];
-  
+
 } pf_cluster_t;
 
 
@@ -103,7 +103,8 @@ typedef struct _pf_sample_set_t
   // Filter statistics
   pf_vector_t mean;
   pf_matrix_t cov;
-  int converged; 
+  int converged;
+  double n_effective;
 } pf_sample_set_t;
 
 
@@ -115,7 +116,7 @@ typedef struct _pf_t
 
   // Population size parameters
   double pop_err, pop_z;
-  
+
   // The sample sets.  We keep two sets and use [current_set]
   // to identify the active set.
   int current_set;
@@ -132,7 +133,7 @@ typedef struct _pf_t
   void *random_pose_data;
 
   double dist_threshold; //distance threshold in each axis over which the pf is considered to not be converged
-  int converged; 
+  int converged;
 } pf_t;
 
 
@@ -183,13 +184,14 @@ void pf_draw_cep_stats(pf_t *pf, struct _rtk_fig_t *fig);
 // Draw the cluster statistics
 void pf_draw_cluster_stats(pf_t *pf, struct _rtk_fig_t *fig);
 
-//calculate if the particle filter has converged - 
-//and sets the converged flag in the current set and the pf 
+//calculate if the particle filter has converged -
+//and sets the converged flag in the current set and the pf
 int pf_update_converged(pf_t *pf);
 
 //sets the current set and pf converged values to zero
 void pf_init_converged(pf_t *pf);
 
+void copy_set(pf_sample_set_t* set_a, pf_sample_set_t* set_b);
 #ifdef __cplusplus
 }
 #endif

--- a/amcl/include/amcl/pf/pf.h
+++ b/amcl/include/amcl/pf/pf.h
@@ -105,6 +105,7 @@ typedef struct _pf_sample_set_t
   pf_matrix_t cov;
   int converged;
   double n_effective;
+  double model_hit_metric;
 } pf_sample_set_t;
 
 

--- a/amcl/include/amcl/pf/pf.h
+++ b/amcl/include/amcl/pf/pf.h
@@ -134,6 +134,8 @@ typedef struct _pf_t
 
   double dist_threshold; //distance threshold in each axis over which the pf is considered to not be converged
   int converged;
+
+  int selective_resampling;
 } pf_t;
 
 
@@ -141,6 +143,8 @@ typedef struct _pf_t
 pf_t *pf_alloc(int min_samples, int max_samples,
                double alpha_slow, double alpha_fast,
                pf_init_model_fn_t random_pose_fn, void *random_pose_data);
+
+void pf_set_selective_resampling(pf_t *pf, int selective_resampling);
 
 // Free an existing filter
 void pf_free(pf_t *pf);

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -110,6 +110,11 @@ pf_t *pf_alloc(int min_samples, int max_samples,
   return pf;
 }
 
+void pf_set_selective_resampling(pf_t *pf, int selective_resampling)
+{
+  pf->selective_resampling = selective_resampling;
+}
+
 // Free an existing filter
 void pf_free(pf_t *pf)
 {
@@ -373,19 +378,22 @@ void pf_update_resample(pf_t *pf)
 
   printf("reasmple neff: %f , N: %d\n", (pf->sets + pf->current_set)->n_effective, (pf->sets + pf->current_set)->sample_count);
 
-  if ((pf->sets + pf->current_set)->n_effective > 0.5*(pf->sets + pf->current_set)->sample_count)
+  if (pf->selective_resampling != 0)
   {
-    printf("skip resample\n");
+    if ((pf->sets + pf->current_set)->n_effective > 0.5*(pf->sets + pf->current_set)->sample_count)
+    {
+      printf("skip resample\n");
 
-    // copy set a to b
-    copy_set(set_a,set_b);
+      // copy set a to b
+      copy_set(set_a,set_b);
 
-    // Re-compute cluster statistics
-    pf_cluster_stats(pf, set_b);
+      // Re-compute cluster statistics
+      pf_cluster_stats(pf, set_b);
 
-    // Use the newly created sample set
-    pf->current_set = (pf->current_set + 1) % 2;
-    return;
+      // Use the newly created sample set
+      pf->current_set = (pf->current_set + 1) % 2;
+      return;
+    }
   }
   printf("resample\n");
 

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -355,6 +355,7 @@ void copy_set(pf_sample_set_t* set_a, pf_sample_set_t* set_b)
   }
 
   set_b->converged = set_a->converged;
+  set_b->model_hit_metric = set_a->model_hit_metric;
 }
 
 
@@ -376,14 +377,10 @@ void pf_update_resample(pf_t *pf)
   set_a = pf->sets + pf->current_set;
   set_b = pf->sets + (pf->current_set + 1) % 2;
 
-  printf("reasmple neff: %f , N: %d\n", (pf->sets + pf->current_set)->n_effective, (pf->sets + pf->current_set)->sample_count);
-
   if (pf->selective_resampling != 0)
   {
     if ((pf->sets + pf->current_set)->n_effective > 0.5*(pf->sets + pf->current_set)->sample_count)
     {
-      printf("skip resample\n");
-
       // copy set a to b
       copy_set(set_a,set_b);
 
@@ -395,7 +392,6 @@ void pf_update_resample(pf_t *pf)
       return;
     }
   }
-  printf("resample\n");
 
   // Build up cumulative probability table for resampling.
   // TODO: Replace this with a more efficient procedure
@@ -508,6 +504,8 @@ void pf_update_resample(pf_t *pf)
   pf->current_set = (pf->current_set + 1) % 2;
 
   pf_update_converged(pf);
+
+  set_b->model_hit_metric = set_a->model_hit_metric;
 
   free(c);
   return;

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -50,7 +50,7 @@ pf_t *pf_alloc(int min_samples, int max_samples,
   pf_t *pf;
   pf_sample_set_t *set;
   pf_sample_t *sample;
-  
+
   srand48(time(NULL));
 
   pf = calloc(1, sizeof(pf_t));
@@ -68,13 +68,13 @@ pf_t *pf_alloc(int min_samples, int max_samples,
   // distrubition will be less than [err].
   pf->pop_err = 0.01;
   pf->pop_z = 3;
-  pf->dist_threshold = 0.5; 
-  
+  pf->dist_threshold = 0.5;
+
   pf->current_set = 0;
   for (j = 0; j < 2; j++)
   {
     set = pf->sets + j;
-      
+
     set->sample_count = max_samples;
     set->samples = calloc(max_samples, sizeof(pf_sample_t));
 
@@ -114,7 +114,7 @@ pf_t *pf_alloc(int min_samples, int max_samples,
 void pf_free(pf_t *pf)
 {
   int i;
-  
+
   for (i = 0; i < 2; i++)
   {
     free(pf->sets[i].clusters);
@@ -122,7 +122,7 @@ void pf_free(pf_t *pf)
     free(pf->sets[i].samples);
   }
   free(pf);
-  
+
   return;
 }
 
@@ -133,16 +133,16 @@ void pf_init(pf_t *pf, pf_vector_t mean, pf_matrix_t cov)
   pf_sample_set_t *set;
   pf_sample_t *sample;
   pf_pdf_gaussian_t *pdf;
-  
+
   set = pf->sets + pf->current_set;
-  
+
   // Create the kd tree for adaptive sampling
   pf_kdtree_clear(set->kdtree);
 
   set->sample_count = pf->max_samples;
 
   pdf = pf_pdf_gaussian_alloc(mean, cov);
-    
+
   // Compute the new sample poses
   for (i = 0; i < set->sample_count; i++)
   {
@@ -157,9 +157,9 @@ void pf_init(pf_t *pf, pf_vector_t mean, pf_matrix_t cov)
   pf->w_slow = pf->w_fast = 0.0;
 
   pf_pdf_gaussian_free(pdf);
-    
+
   // Re-compute cluster statistics
-  pf_cluster_stats(pf, set); 
+  pf_cluster_stats(pf, set);
 
   //set converged to 0
   pf_init_converged(pf);
@@ -197,7 +197,7 @@ void pf_init_model(pf_t *pf, pf_init_model_fn_t init_fn, void *init_data)
 
   // Re-compute cluster statistics
   pf_cluster_stats(pf, set);
-  
+
   //set converged to 0
   pf_init_converged(pf);
 
@@ -207,8 +207,8 @@ void pf_init_model(pf_t *pf, pf_init_model_fn_t init_fn, void *init_data)
 void pf_init_converged(pf_t *pf){
   pf_sample_set_t *set;
   set = pf->sets + pf->current_set;
-  set->converged = 0; 
-  pf->converged = 0; 
+  set->converged = 0;
+  pf->converged = 0;
 }
 
 int pf_update_converged(pf_t *pf)
@@ -229,19 +229,19 @@ int pf_update_converged(pf_t *pf)
   }
   mean_x /= set->sample_count;
   mean_y /= set->sample_count;
-  
+
   for (i = 0; i < set->sample_count; i++){
     sample = set->samples + i;
-    if(fabs(sample->pose.v[0] - mean_x) > pf->dist_threshold || 
+    if(fabs(sample->pose.v[0] - mean_x) > pf->dist_threshold ||
        fabs(sample->pose.v[1] - mean_y) > pf->dist_threshold){
-      set->converged = 0; 
-      pf->converged = 0; 
+      set->converged = 0;
+      pf->converged = 0;
       return 0;
     }
   }
-  set->converged = 1; 
-  pf->converged = 1; 
-  return 1; 
+  set->converged = 1;
+  pf->converged = 1;
+  return 1;
 }
 
 // Update the filter with some new action
@@ -252,10 +252,9 @@ void pf_update_action(pf_t *pf, pf_action_model_fn_t action_fn, void *action_dat
   set = pf->sets + pf->current_set;
 
   (*action_fn) (action_data, set);
-  
+
   return;
 }
-
 
 #include <float.h>
 // Update the filter with some new sensor observation
@@ -270,7 +269,9 @@ void pf_update_sensor(pf_t *pf, pf_sensor_model_fn_t sensor_fn, void *sensor_dat
 
   // Compute the sample weights
   total = (*sensor_fn) (sensor_data, set);
-  
+
+  set->n_effective = 0;
+
   if (total > 0.0)
   {
     // Normalize weights
@@ -280,6 +281,7 @@ void pf_update_sensor(pf_t *pf, pf_sensor_model_fn_t sensor_fn, void *sensor_dat
       sample = set->samples + i;
       w_avg += sample->weight;
       sample->weight /= total;
+      set->n_effective += sample->weight*sample->weight;
     }
     // Update running averages of likelihood of samples (Prob Rob p258)
     w_avg /= set->sample_count;
@@ -291,7 +293,7 @@ void pf_update_sensor(pf_t *pf, pf_sensor_model_fn_t sensor_fn, void *sensor_dat
       pf->w_fast = w_avg;
     else
       pf->w_fast += pf->alpha_fast * (w_avg - pf->w_fast);
-    //printf("w_avg: %e slow: %e fast: %e\n", 
+    //printf("w_avg: %e slow: %e fast: %e\n",
            //w_avg, pf->w_slow, pf->w_fast);
   }
   else
@@ -304,7 +306,50 @@ void pf_update_sensor(pf_t *pf, pf_sensor_model_fn_t sensor_fn, void *sensor_dat
     }
   }
 
+  set->n_effective = 1.0/set->n_effective;
+
   return;
+}
+
+void copy_set(pf_sample_set_t* set_a, pf_sample_set_t* set_b)
+{
+  int i;
+  double total;
+  pf_sample_t *sample_a, *sample_b;
+
+  // Clean set b's kdtree
+  pf_kdtree_clear(set_b->kdtree);
+
+  // Copy samples from set a to create set b
+  total = 0;
+  set_b->sample_count = 0;
+
+  for(i = 0; i < set_a->sample_count; i++)
+  {
+    sample_b = set_b->samples + set_b->sample_count++;
+
+    sample_a = set_a->samples + i;
+
+    assert(sample_a->weight > 0);
+
+    // Copy sample a to sample b
+    sample_b->pose = sample_a->pose;
+    sample_b->weight = sample_a->weight;
+
+    total += sample_b->weight;
+
+    // Add sample to histogram
+    pf_kdtree_insert(set_b->kdtree, sample_b->pose, sample_b->weight);
+  }
+
+  // Normalize weights
+  for (i = 0; i < set_b->sample_count; i++)
+  {
+    sample_b = set_b->samples + i;
+    sample_b->weight /= total;
+  }
+
+  set_b->converged = set_a->converged;
 }
 
 
@@ -326,6 +371,24 @@ void pf_update_resample(pf_t *pf)
   set_a = pf->sets + pf->current_set;
   set_b = pf->sets + (pf->current_set + 1) % 2;
 
+  printf("reasmple neff: %f , N: %d\n", (pf->sets + pf->current_set)->n_effective, (pf->sets + pf->current_set)->sample_count);
+
+  if ((pf->sets + pf->current_set)->n_effective > 0.5*(pf->sets + pf->current_set)->sample_count)
+  {
+    printf("skip resample\n");
+
+    // copy set a to b
+    copy_set(set_a,set_b);
+
+    // Re-compute cluster statistics
+    pf_cluster_stats(pf, set_b);
+
+    // Use the newly created sample set
+    pf->current_set = (pf->current_set + 1) % 2;
+    return;
+  }
+  printf("resample\n");
+
   // Build up cumulative probability table for resampling.
   // TODO: Replace this with a more efficient procedure
   // (e.g., http://www.network-theory.co.uk/docs/gslref/GeneralDiscreteDistributions.html)
@@ -336,7 +399,7 @@ void pf_update_resample(pf_t *pf)
 
   // Create the kd tree for adaptive sampling
   pf_kdtree_clear(set_b->kdtree);
-  
+
   // Draw samples from set a to create set b.
   total = 0;
   set_b->sample_count = 0;
@@ -416,7 +479,7 @@ void pf_update_resample(pf_t *pf)
     if (set_b->sample_count > pf_resample_limit(pf, set_b->kdtree->leaf_count))
       break;
   }
-  
+
   // Reset averages, to avoid spiraling off into complete randomness.
   if(w_diff > 0.0)
     pf->w_slow = pf->w_fast = 0.0;
@@ -429,12 +492,12 @@ void pf_update_resample(pf_t *pf)
     sample_b = set_b->samples + i;
     sample_b->weight /= total;
   }
-  
+
   // Re-compute cluster statistics
   pf_cluster_stats(pf, set_b);
 
   // Use the newly created sample set
-  pf->current_set = (pf->current_set + 1) % 2; 
+  pf->current_set = (pf->current_set + 1) % 2;
 
   pf_update_converged(pf);
 
@@ -464,7 +527,7 @@ int pf_resample_limit(pf_t *pf, int k)
     return pf->min_samples;
   if (n > pf->max_samples)
     return pf->max_samples;
-  
+
   return n;
 }
 
@@ -475,7 +538,7 @@ void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set)
   int i, j, k, cidx;
   pf_sample_t *sample;
   pf_cluster_t *cluster;
-  
+
   // Workspace
   double m[4], c[2][2];
   size_t count;
@@ -483,7 +546,7 @@ void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set)
 
   // Cluster the samples
   pf_kdtree_cluster(set->kdtree);
-  
+
   // Initialize cluster stats
   set->cluster_count = 0;
 
@@ -512,7 +575,7 @@ void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set)
   for (j = 0; j < 2; j++)
     for (k = 0; k < 2; k++)
       c[j][k] = 0.0;
-  
+
   // Compute cluster stats
   for (i = 0; i < set->sample_count; i++)
   {
@@ -522,12 +585,13 @@ void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set)
 
     // Get the cluster label for this sample
     cidx = pf_kdtree_get_cluster(set->kdtree, sample->pose);
+
     assert(cidx >= 0);
     if (cidx >= set->cluster_max_count)
       continue;
     if (cidx + 1 > set->cluster_count)
       set->cluster_count = cidx + 1;
-    
+
     cluster = set->clusters + cidx;
 
     cluster->count += 1;
@@ -551,6 +615,7 @@ void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set)
     for (j = 0; j < 2; j++)
       for (k = 0; k < 2; k++)
       {
+
         cluster->c[j][k] += sample->weight * sample->pose.v[j] * sample->pose.v[k];
         c[j][k] += sample->weight * sample->pose.v[j] * sample->pose.v[k];
       }
@@ -560,7 +625,7 @@ void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set)
   for (i = 0; i < set->cluster_count; i++)
   {
     cluster = set->clusters + i;
-        
+
     cluster->mean.v[0] = cluster->m[0] / cluster->weight;
     cluster->mean.v[1] = cluster->m[1] / cluster->weight;
     cluster->mean.v[2] = atan2(cluster->m[3], cluster->m[2]);
@@ -608,14 +673,14 @@ void pf_get_cep_stats(pf_t *pf, pf_vector_t *mean, double *var)
   double mn, mx, my, mrr;
   pf_sample_set_t *set;
   pf_sample_t *sample;
-  
+
   set = pf->sets + pf->current_set;
 
   mn = 0.0;
   mx = 0.0;
   my = 0.0;
   mrr = 0.0;
-  
+
   for (i = 0; i < set->sample_count; i++)
   {
     sample = set->samples + i;

--- a/amcl/src/amcl/sensors/amcl_laser.cpp
+++ b/amcl/src/amcl/sensors/amcl_laser.cpp
@@ -39,8 +39,8 @@ using namespace amcl;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Default constructor
-AMCLLaser::AMCLLaser(size_t max_beams, map_t* map) : AMCLSensor(), 
-						     max_samples(0), max_obs(0), 
+AMCLLaser::AMCLLaser(size_t max_beams, map_t* map) : AMCLSensor(),
+						     max_samples(0), max_obs(0),
 						     temp_obs(NULL)
 {
   this->time = 0.0;
@@ -57,11 +57,11 @@ AMCLLaser::~AMCLLaser()
 	for(int k=0; k < max_samples; k++){
 	  delete [] temp_obs[k];
 	}
-	delete []temp_obs; 
+	delete []temp_obs;
   }
 }
 
-void 
+void
 AMCLLaser::SetModelBeam(double z_hit,
                         double z_short,
                         double z_max,
@@ -80,7 +80,7 @@ AMCLLaser::SetModelBeam(double z_hit,
   this->chi_outlier = chi_outlier;
 }
 
-void 
+void
 AMCLLaser::SetModelLikelihoodField(double z_hit,
                                    double z_rand,
                                    double sigma_hit,
@@ -94,14 +94,14 @@ AMCLLaser::SetModelLikelihoodField(double z_hit,
   map_update_cspace(this->map, max_occ_dist);
 }
 
-void 
+void
 AMCLLaser::SetModelLikelihoodFieldProb(double z_hit,
 				       double z_rand,
 				       double sigma_hit,
 				       double max_occ_dist,
 				       bool do_beamskip,
 				       double beam_skip_distance,
-				       double beam_skip_threshold, 
+				       double beam_skip_threshold,
 				       double beam_skip_error_threshold)
 {
   this->model_type = LASER_MODEL_LIKELIHOOD_FIELD_PROB;
@@ -127,9 +127,9 @@ bool AMCLLaser::UpdateSensor(pf_t *pf, AMCLSensorData *data)
   if(this->model_type == LASER_MODEL_BEAM)
     pf_update_sensor(pf, (pf_sensor_model_fn_t) BeamModel, data);
   else if(this->model_type == LASER_MODEL_LIKELIHOOD_FIELD)
-    pf_update_sensor(pf, (pf_sensor_model_fn_t) LikelihoodFieldModel, data);  
+    pf_update_sensor(pf, (pf_sensor_model_fn_t) LikelihoodFieldModel, data);
   else if(this->model_type == LASER_MODEL_LIKELIHOOD_FIELD_PROB)
-    pf_update_sensor(pf, (pf_sensor_model_fn_t) LikelihoodFieldModelProb, data);  
+    pf_update_sensor(pf, (pf_sensor_model_fn_t) LikelihoodFieldModelProb, data);
   else
     pf_update_sensor(pf, (pf_sensor_model_fn_t) BeamModel, data);
 
@@ -210,6 +210,8 @@ double AMCLLaser::BeamModel(AMCLLaserData *data, pf_sample_set_t* set)
   return(total_weight);
 }
 
+#include <iostream>
+
 double AMCLLaser::LikelihoodFieldModel(AMCLLaserData *data, pf_sample_set_t* set)
 {
   AMCLLaser *self;
@@ -225,6 +227,13 @@ double AMCLLaser::LikelihoodFieldModel(AMCLLaserData *data, pf_sample_set_t* set
   self = (AMCLLaser*) data->sensor;
 
   total_weight = 0.0;
+
+  unsigned int high_p_norm_hit_count = 0;
+  unsigned int low_p_norm_hit_count = 0;
+  double avg_p_norm_hit = 0;
+  unsigned int high_p_hit_count = 0;
+  unsigned int low_p_hit_count = 0;
+  double avg_p_hit = 0;
 
   // Compute the sample weights
   for (j = 0; j < set->sample_count; j++)
@@ -270,7 +279,7 @@ double AMCLLaser::LikelihoodFieldModel(AMCLLaserData *data, pf_sample_set_t* set
       int mi, mj;
       mi = MAP_GXWX(self->map, hit.v[0]);
       mj = MAP_GYWY(self->map, hit.v[1]);
-      
+
       // Part 1: Get distance from the hit to closest obstacle.
       // Off-map penalized as max distance
       if(!MAP_VALID(self->map, mi, mj))
@@ -280,6 +289,21 @@ double AMCLLaser::LikelihoodFieldModel(AMCLLaserData *data, pf_sample_set_t* set
       // Gaussian model
       // NOTE: this should have a normalization of 1/(sqrt(2pi)*sigma)
       pz += self->z_hit * exp(-(z * z) / z_hit_denom);
+
+      double p_norm_hit = exp(-(z * z) / z_hit_denom) / (sqrt(M_PI*z_hit_denom));  // p_hit ~ N(0,sigma)
+      avg_p_norm_hit += p_norm_hit;
+      if (p_norm_hit > 0.5)
+        high_p_norm_hit_count++;
+      else
+        low_p_norm_hit_count++;
+
+      double p_hit = exp(-(z * z) / z_hit_denom);  // p_hit ~ N(0,sigma)
+      avg_p_hit += p_hit;
+      if (p_hit > 0.5)
+        high_p_hit_count++;
+      else
+        low_p_hit_count++;
+
       // Part 2: random measurements
       pz += self->z_rand * z_rand_mult;
 
@@ -296,6 +320,38 @@ double AMCLLaser::LikelihoodFieldModel(AMCLLaserData *data, pf_sample_set_t* set
     sample->weight *= p;
     total_weight += sample->weight;
   }
+
+    double high_p_norm_hit_ratio;
+    if (high_p_norm_hit_count + low_p_norm_hit_count == 0)
+    {
+      std::cout << "AMCL: No valid beams!" << std::endl;
+      high_p_norm_hit_ratio = 0;
+      avg_p_norm_hit = 0;
+    }
+    else
+    {
+      high_p_norm_hit_ratio = (double)high_p_norm_hit_count/(double)(high_p_norm_hit_count + low_p_norm_hit_count);
+      avg_p_norm_hit /= (double)(high_p_norm_hit_count + low_p_norm_hit_count);
+      // std::cout << "  high_p_norm_hit_ratio: " << high_p_norm_hit_ratio << " avg_p_norm_hit: " << avg_p_norm_hit << " total beams count: " << (high_p_norm_hit_count + low_p_norm_hit_count) << std::endl;
+    }
+
+    double high_p_hit_ratio;
+    if (high_p_hit_count + low_p_hit_count == 0)
+    {
+      std::cout << "AMCL: No valid beams!" << std::endl;
+      high_p_hit_ratio = 0;
+      avg_p_hit = 0;
+    }
+    else
+    {
+      high_p_hit_ratio = (double)high_p_hit_count/(double)(high_p_hit_count + low_p_hit_count);
+      avg_p_hit /= (double)(high_p_hit_count + low_p_hit_count);
+      // std::cout << "  high_p_hit_ratio: " << high_p_hit_ratio << " avg_p_hit: " << avg_p_hit << " total beams count: " << (high_p_hit_count + low_p_hit_count) << std::endl;
+    }
+
+    // keep the metric
+    // self->map_hit_metric = high_p_norm_hit_ratio;
+    set->model_hit_metric = high_p_norm_hit_ratio;
 
   return(total_weight);
 }
@@ -316,8 +372,8 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
 
   total_weight = 0.0;
 
-  step = ceil((data->range_count) / static_cast<double>(self->max_beams)); 
-  
+  step = ceil((data->range_count) / static_cast<double>(self->max_beams));
+
   // Step size must be at least 1
   if(step < 1)
     step = 1;
@@ -329,28 +385,28 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
   double max_dist_prob = exp(-(self->map->max_occ_dist * self->map->max_occ_dist) / z_hit_denom);
 
   //Beam skipping - ignores beams for which a majoirty of particles do not agree with the map
-  //prevents correct particles from getting down weighted because of unexpected obstacles 
-  //such as humans 
+  //prevents correct particles from getting down weighted because of unexpected obstacles
+  //such as humans
 
   bool do_beamskip = self->do_beamskip;
   double beam_skip_distance = self->beam_skip_distance;
   double beam_skip_threshold = self->beam_skip_threshold;
-  
-  //we only do beam skipping if the filter has converged 
+
+  //we only do beam skipping if the filter has converged
   if(do_beamskip && !set->converged){
     do_beamskip = false;
   }
 
-  //we need a count the no of particles for which the beam agreed with the map 
+  //we need a count the no of particles for which the beam agreed with the map
   int *obs_count = new int[self->max_beams]();
 
-  //we also need a mask of which observations to integrate (to decide which beams to integrate to all particles) 
+  //we also need a mask of which observations to integrate (to decide which beams to integrate to all particles)
   bool *obs_mask = new bool[self->max_beams]();
-  
+
   int beam_ind = 0;
-  
-  //realloc indicates if we need to reallocate the temp data structure needed to do beamskipping 
-  bool realloc = false; 
+
+  //realloc indicates if we need to reallocate the temp data structure needed to do beamskipping
+  bool realloc = false;
 
   if(do_beamskip){
     if(self->max_obs < self->max_beams){
@@ -362,7 +418,7 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
     }
 
     if(realloc){
-      self->reallocTempData(set->sample_count, self->max_beams);     
+      self->reallocTempData(set->sample_count, self->max_beams);
       fprintf(stderr, "Reallocing temp weights %d - %d\n", self->max_samples, self->max_obs);
     }
   }
@@ -377,9 +433,9 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
     pose = pf_vector_coord_add(self->laser_pose, pose);
 
     log_p = 0;
-    
+
     beam_ind = 0;
-    
+
     for (i = 0; i < data->range_count; i += step, beam_ind++)
     {
       obs_range = data->ranges[i][0];
@@ -405,10 +461,10 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
       int mi, mj;
       mi = MAP_GXWX(self->map, hit.v[0]);
       mj = MAP_GYWY(self->map, hit.v[1]);
-      
+
       // Part 1: Get distance from the hit to closest obstacle.
       // Off-map penalized as max distance
-      
+
       if(!MAP_VALID(self->map, mi, mj)){
 	pz += self->z_hit * max_dist_prob;
       }
@@ -419,23 +475,23 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
 	}
 	pz += self->z_hit * exp(-(z * z) / z_hit_denom);
       }
-       
+
       // Gaussian model
       // NOTE: this should have a normalization of 1/(sqrt(2pi)*sigma)
-      
+
       // Part 2: random measurements
       pz += self->z_rand * z_rand_mult;
 
-      assert(pz <= 1.0); 
+      assert(pz <= 1.0);
       assert(pz >= 0.0);
 
       // TODO: outlier rejection for short readings
-            
+
       if(!do_beamskip){
 	log_p += log(pz);
       }
       else{
-	self->temp_obs[j][beam_ind] = pz; 
+	self->temp_obs[j][beam_ind] = pz;
       }
     }
     if(!do_beamskip){
@@ -443,28 +499,28 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
       total_weight += sample->weight;
     }
   }
-  
+
   if(do_beamskip){
-    int skipped_beam_count = 0; 
+    int skipped_beam_count = 0;
     for (beam_ind = 0; beam_ind < self->max_beams; beam_ind++){
       if((obs_count[beam_ind] / static_cast<double>(set->sample_count)) > beam_skip_threshold){
 	obs_mask[beam_ind] = true;
       }
       else{
 	obs_mask[beam_ind] = false;
-	skipped_beam_count++; 
+	skipped_beam_count++;
       }
     }
 
-    //we check if there is at least a critical number of beams that agreed with the map 
+    //we check if there is at least a critical number of beams that agreed with the map
     //otherwise it probably indicates that the filter converged to a wrong solution
-    //if that's the case we integrate all the beams and hope the filter might converge to 
+    //if that's the case we integrate all the beams and hope the filter might converge to
     //the right solution
-    bool error = false; 
+    bool error = false;
 
     if(skipped_beam_count >= (beam_ind * self->beam_skip_error_threshold)){
       fprintf(stderr, "Over %f%% of the observations were not in the map - pf may have converged to wrong pose - integrating all observations\n", (100 * self->beam_skip_error_threshold));
-      error = true; 
+      error = true;
     }
 
     for (j = 0; j < set->sample_count; j++)
@@ -479,14 +535,14 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
 	    log_p += log(self->temp_obs[j][beam_ind]);
 	  }
 	}
-	
+
 	sample->weight *= exp(log_p);
-	
+
 	total_weight += sample->weight;
-      }      
+      }
   }
 
-  delete [] obs_count; 
+  delete [] obs_count;
   delete [] obs_mask;
   return(total_weight);
 }
@@ -496,10 +552,10 @@ void AMCLLaser::reallocTempData(int new_max_samples, int new_max_obs){
     for(int k=0; k < max_samples; k++){
       delete [] temp_obs[k];
     }
-    delete []temp_obs; 
+    delete []temp_obs;
   }
-  max_obs = new_max_obs; 
-  max_samples = fmax(max_samples, new_max_samples); 
+  max_obs = new_max_obs;
+  max_samples = fmax(max_samples, new_max_samples);
 
   temp_obs = new double*[max_samples]();
   for(int k=0; k < max_samples; k++){

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -274,6 +274,7 @@ class AmclNode
     double init_cov_[3];
     laser_model_t laser_model_type_;
     bool tf_broadcast_;
+    bool selective_resampling_;
 
     void reconfigureCB(amcl::AMCLConfig &config, uint32_t level);
 
@@ -362,6 +363,7 @@ AmclNode::AmclNode() :
   private_nh_.param("odom_alpha3", alpha3_, 0.2);
   private_nh_.param("odom_alpha4", alpha4_, 0.2);
   private_nh_.param("odom_alpha5", alpha5_, 0.2);
+  private_nh_.param("selective_resampling", selective_resampling_, false);
 
   private_nh_.param("do_beamskip", do_beamskip_, false);
   private_nh_.param("beam_skip_distance", beam_skip_distance_, 0.5);
@@ -563,6 +565,8 @@ void AmclNode::reconfigureCB(AMCLConfig &config, uint32_t level)
                  alpha_slow_, alpha_fast_,
                  (pf_init_model_fn_t)AmclNode::uniformPoseGenerator,
                  (void *)map_);
+  pf_set_selective_resampling(pf_, selective_resampling_);
+
   pf_err_ = config.kld_err;
   pf_z_ = config.kld_z;
   pf_->pop_err = pf_err_;
@@ -855,6 +859,8 @@ AmclNode::handleMapMessage(const nav_msgs::OccupancyGrid& msg)
                  alpha_slow_, alpha_fast_,
                  (pf_init_model_fn_t)AmclNode::uniformPoseGenerator,
                  (void *)map_);
+  pf_set_selective_resampling(pf_, selective_resampling_);
+
   pf_->pop_err = pf_err_;
   pf_->pop_z = pf_z_;
 


### PR DESCRIPTION
The PR adds and fixes several features:
1. Cancel updating on timeout, only publish.
- Advantage: The PF's covariance will not become infinitesimally small anymore when the robot is static and the particles deprivation would stop. In addition, we also not integrating new measurements as they bring no new information when the robot is static.
- Disadvantage: If current AMCL pose is not correct and the robot doesn't move, it would not update and converge to correct pose until the robot moves, but it would publish. This situation is rare.

2. Selective Resampling:
Implement selective resampling as described in `Improving Grid-based SLAM with Rao-Blackwellized Particle / Grisetti, Stachniss, Burgard`
Filters by Adaptive Proposals and Selective Resampling
The parameter to enable: `selective_resampling` (default: false)

3. Modulate the covariance using the map_hit_metric. `new_covariance = old_covariance/metric`. 
New covariance would be bigger then the old one, and would become bigger the less the observation fit the map.
The parameter to enable: `modulate_covariance` (default: false)
